### PR TITLE
register parsed components with createNodeByType

### DIFF
--- a/src/brsTypes/components/BrsObjects.ts
+++ b/src/brsTypes/components/BrsObjects.ts
@@ -5,13 +5,21 @@ import { RoSGNode, createNodeByType } from "./RoSGNode";
 import { RoRegex } from "./RoRegex";
 import { BrsString } from "../BrsType";
 import { RoString } from "./RoString";
+import { Interpreter } from "../../interpreter";
 
 /** Map containing a list of brightscript components that can be created. */
 export const BrsObjects = new Map<string, Function>([
-    ["roassociativearray", () => new RoAssociativeArray([])],
-    ["roarray", () => new RoArray([])],
-    ["rotimespan", () => new Timespan()],
-    ["rosgnode", (nodeType: BrsString) => createNodeByType(nodeType)],
-    ["roregex", (expression: BrsString, flags: BrsString) => new RoRegex(expression, flags)],
-    ["rostring", (literal: BrsString) => new RoString(literal)],
+    ["roassociativearray", (interpreter: Interpreter) => new RoAssociativeArray([])],
+    ["roarray", (interpreter: Interpreter) => new RoArray([])],
+    ["rotimespan", (interpreter: Interpreter) => new Timespan()],
+    [
+        "rosgnode",
+        (interpreter: Interpreter, nodeType: BrsString) => createNodeByType(interpreter, nodeType),
+    ],
+    [
+        "roregex",
+        (interpreter: Interpreter, expression: BrsString, flags: BrsString) =>
+            new RoRegex(expression, flags),
+    ],
+    ["rostring", (interpreter: Interpreter, literal: BrsString) => new RoString(literal)],
 ]);

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -650,7 +650,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         impl: (interpreter: Interpreter, nodetype: BrsString) => {
             // currently we can't create a custom subclass object of roSGNode,
             // so we'll always create generic RoSGNode object as child
-            let child = createNodeByType(nodetype);
+            let child = createNodeByType(interpreter, nodetype);
             if (child instanceof RoSGNode) {
                 this.children.push(child);
                 child.setParent(this);
@@ -726,9 +726,14 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
     });
 }
 
-export function createNodeByType(type: BrsString) {
+export function createNodeByType(interpreter: Interpreter, type: BrsString) {
+    let typeDef = interpreter.environment.nodeDefMap.get(type.value);
     if (type.value === "Node") {
         return new RoSGNode([]);
+    } else if (typeDef !== undefined) {
+        //TODO: use typeDef object to tack on all the bells & whistles of a custom node
+        let newNode = new RoSGNode([]);
+        return newNode;
     } else {
         return BrsInvalid.Instance;
     }

--- a/src/componentprocessor/index.ts
+++ b/src/componentprocessor/index.ts
@@ -9,7 +9,7 @@ import * as fg from "fast-glob";
 export class ComponentDefinition {
     public contents?: string;
     public xmlNode?: XmlDocument;
-    public name: string = "";
+    public name?: string;
 
     constructor(readonly xmlPath: string) {}
 

--- a/src/componentprocessor/index.ts
+++ b/src/componentprocessor/index.ts
@@ -4,22 +4,24 @@ import { promisify } from "util";
 import xmldoc, { XmlDocument } from "xmldoc";
 import pSettle = require("p-settle");
 const readFile = promisify(fs.readFile);
-const fg = require("fast-glob");
+import * as fg from "fast-glob";
 
 export class ComponentDefinition {
     public contents?: string;
-    public isFulfilled: boolean = true;
+    public xmlNode?: XmlDocument;
+    public name: string = "";
 
     constructor(readonly xmlPath: string) {}
 
-    async parse(): Promise<XmlDocument | string> {
+    async parse(): Promise<ComponentDefinition> {
         let contents;
         try {
             contents = await readFile(this.xmlPath, "utf-8");
-            let xmlStr = contents.toString();
-            let xmlNode = new xmldoc.XmlDocument(xmlStr);
+            let xmlStr = contents.toString().replace(/\r?\n|\r/g, "");
+            this.xmlNode = new xmldoc.XmlDocument(xmlStr);
+            this.name = this.xmlNode.attr.name;
 
-            return Promise.resolve(xmlNode);
+            return Promise.resolve(this);
         } catch (err) {
             console.log("some error");
             console.log(err);
@@ -27,15 +29,12 @@ export class ComponentDefinition {
             //   cases:
             //     * file read error
             //     * XML parse error
-            return Promise.reject("error");
-            // return Promise.reject({
-            //     message: "Error parsing XML: " + this.xmlPath
-            // });
+            return Promise.reject(this);
         }
     }
 }
 
-export async function getComponentDefinitions(rootDir: string): Promise<Object[]> {
+export async function getComponentDefinitions(rootDir: string) {
     const componentsPattern = rootDir + "/components/**/*.xml";
     const xmlFiles: string[] = fg.sync(componentsPattern, {});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ const readFile = promisify(fs.readFile);
 
 import { Lexer } from "./lexer";
 import * as PP from "./preprocessor";
-import { getComponentDefinitions, ComponentDefinition } from "./componentprocessor";
+import { getComponentDefinitions } from "./componentprocessor";
 import { Parser } from "./parser";
 import { Interpreter, ExecutionOptions, defaultExecutionOptions } from "./interpreter";
 import * as BrsError from "./Error";
@@ -99,8 +99,8 @@ export async function execute(filenames: string[], options: Partial<ExecutionOpt
     // save each custom component def into a global map so we can access it
     // at run time when we call `createObjectByType`
     nodeDefs.map(node => {
-        if (node.isFulfilled) {
-            interpreter.environment.nodeDefMap.set(node.value!.name, node.value!);
+        if (node.isFulfilled && !node.isRejected) {
+            interpreter.environment.nodeDefMap.set(node.value!.name!, node.value!);
         }
     });
     return interpreter.exec(statements);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ const readFile = promisify(fs.readFile);
 
 import { Lexer } from "./lexer";
 import * as PP from "./preprocessor";
-import { getComponentDefinitions } from "./componentprocessor";
+import { getComponentDefinitions, ComponentDefinition } from "./componentprocessor";
 import { Parser } from "./parser";
 import { Interpreter, ExecutionOptions, defaultExecutionOptions } from "./interpreter";
 import * as BrsError from "./Error";
@@ -96,6 +96,13 @@ export async function execute(filenames: string[], options: Partial<ExecutionOpt
     // execute them
     const interpreter = new Interpreter(executionOptions);
     interpreter.onError(logError);
+    // save each custom component def into a global map so we can access it
+    // at run time when we call `createObjectByType`
+    nodeDefs.map(node => {
+        if (node.isFulfilled) {
+            interpreter.environment.nodeDefMap.set(node.value!.name, node.value!);
+        }
+    });
     return interpreter.exec(statements);
 }
 

--- a/src/interpreter/Environment.ts
+++ b/src/interpreter/Environment.ts
@@ -1,5 +1,6 @@
 import { Identifier } from "../lexer";
 import { BrsType, RoAssociativeArray, Int32, BrsInvalid, RoSGNode } from "../brsTypes";
+import { ComponentDefinition } from "../componentprocessor";
 
 /** The logical region from a particular variable or function that defines where it may be accessed from. */
 export enum Scope {
@@ -44,6 +45,9 @@ export class Environment {
      * of stealing focus away from another node if a new node got focus.
      */
     private focusedNode: RoSGNode | BrsInvalid = BrsInvalid.Instance;
+
+    /** Map holding component definitions of all parsed xml component files */
+    public nodeDefMap = new Map<string, ComponentDefinition>();
 
     /**
      * Stores a `value` for the `name`d variable in the provided `scope`.
@@ -175,6 +179,7 @@ export class Environment {
         newEnvironment.module = this.module;
         newEnvironment.mPointer = this.mPointer;
         newEnvironment.focusedNode = this.focusedNode;
+        newEnvironment.nodeDefMap = this.nodeDefMap;
 
         return newEnvironment;
     }

--- a/src/stdlib/CreateObject.ts
+++ b/src/stdlib/CreateObject.ts
@@ -17,6 +17,6 @@ export const CreateObject = new Callable("CreateObject", {
     },
     impl: (interpreter: Interpreter, objName: BrsString, ...additionalArgs: BrsType[]) => {
         let ctor = BrsObjects.get(objName.value.toLowerCase());
-        return ctor ? ctor(...additionalArgs) : BrsInvalid.Instance;
+        return ctor ? ctor(interpreter, ...additionalArgs) : BrsInvalid.Instance;
     },
 });

--- a/test/componentprocessor/componentprocessor.test.js
+++ b/test/componentprocessor/componentprocessor.test.js
@@ -1,7 +1,6 @@
 const xmldoc = require("xmldoc");
 const { componentprocessor } = require("brs");
 const { getComponentDefinitions, ComponentDefinition } = require("../../lib/componentprocessor");
-const { Interpreter } = require("../../../lib/interpreter");
 
 jest.mock("fast-glob");
 jest.mock("fs");

--- a/test/componentprocessor/componentprocessor.test.js
+++ b/test/componentprocessor/componentprocessor.test.js
@@ -34,7 +34,7 @@ describe.only("component parsing support", () => {
             );
 
             let badDef = new ComponentDefinition("/some/valid/path.xml");
-            expect(badDef.parse()).rejects.toMatch(badDef);
+            expect(badDef.parse()).rejects.toBe(badDef);
         });
 
         it("parses well-defined component definition", async () => {

--- a/test/componentprocessor/componentprocessor.test.js
+++ b/test/componentprocessor/componentprocessor.test.js
@@ -37,7 +37,7 @@ describe.only("component parsing support", () => {
             expect(badDef.parse()).rejects.toMatch(badDef);
         });
 
-        it("registers a component definition", async () => {
+        it("parses well-defined component definition", async () => {
             const goodDefXml = `
 <?xml version="1.0" encoding="utf-8" ?>
 <component name="GoodComponent" extends="BaseComponent">

--- a/test/componentprocessor/componentprocessor.test.js
+++ b/test/componentprocessor/componentprocessor.test.js
@@ -1,6 +1,7 @@
 const xmldoc = require("xmldoc");
 const { componentprocessor } = require("brs");
 const { getComponentDefinitions, ComponentDefinition } = require("../../lib/componentprocessor");
+const { Interpreter } = require("../../../lib/interpreter");
 
 jest.mock("fast-glob");
 jest.mock("fs");
@@ -34,10 +35,10 @@ describe.only("component parsing support", () => {
             );
 
             let badDef = new ComponentDefinition("/some/valid/path.xml");
-            expect(badDef.parse()).rejects.toMatch("error");
+            expect(badDef.parse()).rejects.toMatch(badDef);
         });
 
-        it("parses well-defined component definition", async () => {
+        it("registers a component definition", async () => {
             const goodDefXml = `
 <?xml version="1.0" encoding="utf-8" ?>
 <component name="GoodComponent" extends="BaseComponent">
@@ -49,11 +50,10 @@ describe.only("component parsing support", () => {
 
             let goodDef = new ComponentDefinition("/some/valid/path.xml");
             let parsed = await goodDef.parse();
-
-            expect(parsed).toBeInstanceOf(xmldoc.XmlDocument);
-            expect(parsed.name).toEqual("component");
-            expect(parsed.attr.name).toEqual("GoodComponent");
-            expect(parsed.attr.extends).toEqual("BaseComponent");
+            let xmlNode = parsed.xmlNode;
+            expect(xmlNode.name).toEqual("component");
+            expect(xmlNode.attr.name).toEqual("GoodComponent");
+            expect(xmlNode.attr.extends).toEqual("BaseComponent");
         });
     });
 });


### PR DESCRIPTION
- this adds parsed component definitions onto the global environment and let us have access to the definitions at run time when `createNoteByType()` is called