### PR TITLE
More ifSGNodeDict interface methods

### DIFF
--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -735,8 +735,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             returns: ValueKind.Boolean,
         },
         impl: (interpreter: Interpreter, roSGNode: RoSGNode) => {
-            let sameNode = this === roSGNode;
-            return sameNode ? BrsBoolean.True : BrsBoolean.False;
+            return BrsBoolean.from(this === roSGNode);
         },
     });
 

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -106,6 +106,8 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             this.isinfocuschain,
             //ifSGNodeDict
             this.findnode,
+            this.issamenode,
+            this.subtype,
         ]);
     }
 
@@ -722,6 +724,30 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
 
             // perform search
             return this.findNodeById(root, name);
+        },
+    });
+
+    /* Returns a Boolean value indicating whether the roSGNode parameter
+            refers to the same node object as the subject node */
+    private issamenode = new Callable("issamenode", {
+        signature: {
+            args: [new StdlibArgument("roSGNode", ValueKind.Dynamic)],
+            returns: ValueKind.Boolean,
+        },
+        impl: (interpreter: Interpreter, roSGNode: RoSGNode) => {
+            let sameNode = this === roSGNode;
+            return sameNode ? BrsBoolean.True : BrsBoolean.False;
+        },
+    });
+
+    /* TODO */
+    private subtype = new Callable("subtype", {
+        signature: {
+            args: [],
+            returns: ValueKind.String,
+        },
+        impl: (interpreter: Interpreter) => {
+            return new BrsString(this.type);
         },
     });
 }

--- a/src/brsTypes/components/RoSGNode.ts
+++ b/src/brsTypes/components/RoSGNode.ts
@@ -728,7 +728,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
     });
 
     /* Returns a Boolean value indicating whether the roSGNode parameter
-            refers to the same node object as the subject node */
+            refers to the same node object as this node */
     private issamenode = new Callable("issamenode", {
         signature: {
             args: [new StdlibArgument("roSGNode", ValueKind.Dynamic)],
@@ -740,7 +740,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         },
     });
 
-    /* TODO */
+    /* Returns the subtype of this node as specified when it was created */
     private subtype = new Callable("subtype", {
         signature: {
             args: [],

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -1231,5 +1231,43 @@ describe("RoSGNode", () => {
                 expect(parent).toBe(result);
             });
         });
+
+        describe("issamenode", () => {
+            it("returns true if the nodes are the same", () => {
+                let isSameNode = parent.getMethod("issamenode");
+                expect(isSameNode).toBeTruthy();
+
+                let result = isSameNode.call(interpreter, parent);
+                expect(result).toBe(BrsBoolean.True);
+            });
+
+            it("returns false if the nodes are different", () => {
+                let isSameNode = parent.getMethod("issamenode");
+
+                let result = isSameNode.call(interpreter, child4);
+                expect(result).toBe(BrsBoolean.False);
+            });
+        });
+
+        describe("subtype", () => {
+            it("returns 'Node' for Node roSGNode", () => {
+                let subtype = parent.getMethod("subtype");
+                expect(subtype).toBeTruthy();
+
+                let result = subtype.call(interpreter);
+                expect(result.value).toBe(new BrsString("Node").value);
+            });
+
+            it("returns type for arbitrary roSGNode", () => {
+                let someNode = new RoSGNode(
+                    [{ name: new BrsString("id"), value: new BrsString("someNode") }],
+                    "randomType"
+                );
+                let subtype = someNode.getMethod("subtype");
+
+                let result = subtype.call(interpreter);
+                expect(result.value).toBe(new BrsString("randomType").value);
+            });
+        });
     });
 });

--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -1255,7 +1255,7 @@ describe("RoSGNode", () => {
                 expect(subtype).toBeTruthy();
 
                 let result = subtype.call(interpreter);
-                expect(result.value).toBe(new BrsString("Node").value);
+                expect(result.value).toBe("Node");
             });
 
             it("returns type for arbitrary roSGNode", () => {
@@ -1266,7 +1266,7 @@ describe("RoSGNode", () => {
                 let subtype = someNode.getMethod("subtype");
 
                 let result = subtype.call(interpreter);
-                expect(result.value).toBe(new BrsString("randomType").value);
+                expect(result.value).toBe("randomType");
             });
         });
     });

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -145,6 +145,12 @@ describe("end to end brightscript functions", () => {
             "Cousin-2",
             "node finds its grandparent: ",
             "root-node",
+            "is same node returns true:",
+            "true",
+            "is same node returns false:",
+            "false",
+            "Node subtype is returned:",
+            "Node",
         ]);
     });
 

--- a/test/e2e/resources/components/roSGNode.brs
+++ b/test/e2e/resources/components/roSGNode.brs
@@ -22,7 +22,7 @@ sub main()
     node1.addFields({ field2: 0, field3: false})
 
     print "node size: " node1.count()                              ' => 3
-    
+
     node1.removeField("field2")
     print "node size: " node1.count()                              ' => 2
 
@@ -130,6 +130,17 @@ sub main()
     ' finds its grandparent
     result = cousin2.findNode("root")
     print "node finds its grandparent: " result.name                ' => root-node
+
+    ' returns true if both nodes are the same
+    n = createObject("roSGNode", "Node")
+    c = n.createChild("Node")
+    print "is same node returns true:" c.isSameNode(n.getChildren(-1, 0)[0])    ' => true
+
+    ' returns false if two different nodes are used
+    print "is same node returns false:" c.isSameNode(n)                ' => false
+
+    ' returns the node subtype
+    print "Node subtype is returned:" n.subtype()                       ' => Node
 end sub
 
 sub onSomethingChanged()


### PR DESCRIPTION
This change implements `isSameNode` and `subtype` methods from `ifSGNodeDict` interface.

I'm still trying to figure out how we could implement the `clone` and `parentSubtype` methods.
The `isSubtype` method will rely on having a global list of node definitions so it is not implemented either.
https://developer.roku.com/docs/references/brightscript/interfaces/ifsgnodedict.md